### PR TITLE
luci-app-mosdns: init.d: set default working path

### DIFF
--- a/luci-app-mosdns/root/etc/init.d/mosdns
+++ b/luci-app-mosdns/root/etc/init.d/mosdns
@@ -212,11 +212,12 @@ start_service() {
     fi
     procd_open_instance mosdns
     procd_set_param env QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING=true
-    procd_set_param command $PROG start -c "$CONF"
-    procd_set_param user root
+    procd_set_param command $PROG start
+    procd_append_param command -c "$CONF"
+    procd_append_param command -d "/etc/mosdns"
     procd_set_param stdout 1
     procd_set_param stderr 1
-    procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
+    procd_set_param respawn
     procd_close_instance mosdns
     [ "$redirect" -ne 1 ] && [ -f "/etc/mosdns/redirect.lock" ] && restore_setting
     [ "$redirect" -eq 1 ] && redirect_setting


### PR DESCRIPTION
* Allow custom configuration files to use relative paths for the /etc/mosdns directory